### PR TITLE
fin/input (children props를 넘겨서 컴포넌트 배치, password show 기능)

### DIFF
--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -13,6 +13,7 @@ interface PropsType {
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   placeholder?: string;
   keyDownHandler?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+  children?: React.ReactNode;
 }
 
 const Input = ({
@@ -26,12 +27,15 @@ const Input = ({
   onChange,
   placeholder,
   keyDownHandler,
+  children,
 }: PropsType) => {
+  const [isViewPassword, setIsViewPassword] = useState(false);
   const [isError, setIsError] = useState(false);
   const inputContainerClassName = isError ? "input-container error" : "input-container";
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValue(e.target.value);
   };
+  const handleIsViewPassword = () => setIsViewPassword((prev) => !prev);
 
   useEffect(() => {
     setIsError(errorMessage?.length > 0);
@@ -43,34 +47,38 @@ const Input = ({
       <div className="input-wrapper">
         <input
           id={id}
-          type={type}
+          type={isViewPassword ? "text" : type}
           value={value}
           onChange={onChange || handleChange}
           onKeyDown={keyDownHandler}
           placeholder={placeholder}
         />
-        <svg
-          width="20"
-          height="20"
-          viewBox="0 0 20 20"
-          fill="none"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12.5 9.99996C12.5 10.663 12.2366 11.2989 11.7678 11.7677C11.2989 12.2366 10.663 12.5 10 12.5C9.33697 12.5 8.70108 12.2366 8.23224 11.7677C7.7634 11.2989 7.50001 10.663 7.50001 9.99996C7.50001 9.33692 7.7634 8.70103 8.23224 8.23219C8.70108 7.76335 9.33697 7.49996 10 7.49996C10.663 7.49996 11.2989 7.76335 11.7678 8.23219C12.2366 8.70103 12.5 9.33692 12.5 9.99996Z"
-            stroke="#DBDBDB"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-          <path
-            d="M2.04834 9.99996C3.11001 6.61913 6.26917 4.16663 10 4.16663C13.7317 4.16663 16.89 6.61913 17.9517 9.99996C16.89 13.3808 13.7317 15.8333 10 15.8333C6.26917 15.8333 3.11001 13.3808 2.04834 9.99996Z"
-            stroke="#DBDBDB"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          />
-        </svg>
+        {type === "password" && (
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            onClick={handleIsViewPassword}
+          >
+            <path
+              d="M12.5 9.99996C12.5 10.663 12.2366 11.2989 11.7678 11.7677C11.2989 12.2366 10.663 12.5 10 12.5C9.33697 12.5 8.70108 12.2366 8.23224 11.7677C7.7634 11.2989 7.50001 10.663 7.50001 9.99996C7.50001 9.33692 7.7634 8.70103 8.23224 8.23219C8.70108 7.76335 9.33697 7.49996 10 7.49996C10.663 7.49996 11.2989 7.76335 11.7678 8.23219C12.2366 8.70103 12.5 9.33692 12.5 9.99996Z"
+              stroke="#DBDBDB"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+            <path
+              d="M2.04834 9.99996C3.11001 6.61913 6.26917 4.16663 10 4.16663C13.7317 4.16663 16.89 6.61913 17.9517 9.99996C16.89 13.3808 13.7317 15.8333 10 15.8333C6.26917 15.8333 3.11001 13.3808 2.04834 9.99996Z"
+              stroke="#DBDBDB"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        )}
+        {children && <div className="children-wrapper">{children}</div>}
       </div>
 
       {isError && <p>{errorMessage}</p>}

--- a/frontend/src/styles/components/common.scss
+++ b/frontend/src/styles/components/common.scss
@@ -139,12 +139,13 @@
   overflow: hidden;
 
   svg {
-    display: none;
-    margin-left: 4px;
+    cursor: pointer;
+    margin-left: 16px;
   }
 
   input {
     flex: 1;
+    width: 100%;
     border: 0;
     outline: none;
     color: $black;
@@ -160,11 +161,11 @@
 
   &:focus-within {
     box-shadow: 0 0 0 1px $main-blue-100 inset;
-
-    svg {
-      display: block;
-    }
   }
+}
+
+.children-wrapper {
+  margin-left: 16px;
 }
 
 // input end


### PR DESCRIPTION
## 작업사항(content)
- type을 password로 설정했을 때 패스워드 보이기/안보이기 기능 사용할 수 있도록 변경
- children을 전달하면 input 오른쪽에 배치되도록 변경
ex)
```js
<Input ...props>
    <div>인증 완료</div>
<Input>
```

## 참고자료(Links)
-

## 주의사항(Caution)
- 

## 기타사항(Etc)
- figma에 눈 닫힘 아이콘이 없어서 password를 보여준다고 해도 아이콘의 변화가 없습니다.
